### PR TITLE
A widget's currency selection must affect the other widget's amount

### DIFF
--- a/src/App.e2e.test.js
+++ b/src/App.e2e.test.js
@@ -67,10 +67,10 @@ describe('<App />', () => {
       })
       expect(() =>
         app.find('.fxp-currency').at(0).find('.fxp-currency__amount').props().value
-      ).toEqual(1.25)
+      ).toEqual(1)
       expect(() =>
         app.find('.fxp-currency').at(1).find('.fxp-currency__amount').props().value
-      ).toEqual(1.25)
+      ).toEqual(1)
     })()
   })
 })

--- a/src/App.js
+++ b/src/App.js
@@ -24,12 +24,19 @@ class App extends Component {
 
   onCurrencyEdited(payload) {
     const idx = payload.uuid
-    const newState = [
+    const newWidgetsState = [
       ...this.state.widgets.slice(0, idx),
       payload.currency,
       ...this.state.widgets.slice(idx+1)
     ]
-    this.setState({widgets: newState})
+    const newBaseState = {
+      amount: payload.amount,
+      currency: payload.currency
+    }
+    this.setState({
+      widgets: newWidgetsState,
+      base: newBaseState
+    })
   }
 
   convertAmounts() {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -92,6 +92,7 @@ describe('<App />', () => {
       it('is updated upon onCurrencyEdited()', () => {
         const payload = {
           uuid: 0,
+          amount: 42,
           currency: 'USD'
         }
         const newState = ['USD', 'USD']
@@ -116,6 +117,20 @@ describe('<App />', () => {
           currency: 'EUR'
         }
         wrapper.instance().onAmountEdited(newState)
+        expect(wrapper).toHaveState('base', newState)
+      })
+
+      it('is updated upon onCurrencyEdited()', () => {
+        const payload = {
+          uuid: 0,
+          amount: 42,
+          currency: 'USD'
+        }
+        const newState = {
+          amount: 42,
+          currency: 'USD'
+        }
+        wrapper.instance().onCurrencyEdited(payload)
         expect(wrapper).toHaveState('base', newState)
       })
     })

--- a/src/Currency.js
+++ b/src/Currency.js
@@ -12,6 +12,7 @@ class Currency extends React.Component {
   onCurrencyEdited(event) {
     this.props.onCurrencyEdited({
       uuid: this.props.uuid,
+      amount: this.props.amount,
       currency: event.target.value
     })
   }

--- a/src/Currency.test.js
+++ b/src/Currency.test.js
@@ -11,6 +11,7 @@ describe('<Currency />', () => {
     type: 'quote',
     currency: 'EUR',
     currencies: ['EUR', 'USD'],
+    amount: 42,
     onAmountEdited: () => {},
     onCurrencyEdited: () => {}
   }
@@ -178,6 +179,7 @@ describe('<Currency />', () => {
         expect(spy).toHaveBeenCalledTimes(1)
         expect(spy).toHaveBeenLastCalledWith({
           uuid: 0,
+          amount: 42,
           currency: 'USD'
         })
       })


### PR DESCRIPTION
Fixes #20.